### PR TITLE
Added Correct Suffix for PNG file when the page option is not equal to 1

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const runPDFBox = (filePath, options, callback) => {
       if (err) return callback(err)
 
       uri.suffix(options.imageType)
-      const pdfBoxImageFilePath = constants.DIRECTORY.PDF + uri.filename().replace(new RegExp(`.${uri.suffix()}$`), `1.${uri.suffix()}`)
+      const pdfBoxImageFilePath = constants.DIRECTORY.PDF + uri.filename().replace(new RegExp(`.${uri.suffix()}$`), `${options.page}.${uri.suffix()}`)
       const imageFilePath = constants.DIRECTORY.IMAGE + uri.filename()
       // Resize image
       gm(pdfBoxImageFilePath)


### PR DESCRIPTION
@shebinleo ,  I am trying to use the repo to convert pdf to thumbnail. 
While doing so I came across scenario where my pdf is having multiple pages. I was trying to use the page option in thumbnail method, but it was giving error as it was trying to copy .png image stored in **/node-modules/pdftohtml/files/pdf** folder with name eg, **Actual1.png**. But if the page size is 2 then the file is **Actual2.png** hence resulting in the error 
No Such File found. 

So to fix this issue I have fixed the path from where file is getting copied. 
Can you please review it?  
