### PR TITLE
adjust url to download tika and pdfbox

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -3,8 +3,8 @@ const fs = require('fs')
 const constants = require('./constants')
 
 const dependencies = {
-  [constants.VENDOR_PDF_BOX_JAR]: 'https://dlcdn.apache.org/pdfbox/2.0.24/pdfbox-app-2.0.24.jar',
-  [constants.VENDOR_TIKA_JAR]: 'https://dlcdn.apache.org/tika/2.1.0/tika-app-2.1.0.jar'
+  [constants.VENDOR_PDF_BOX_JAR]: 'http://archive.apache.org/dist/pdfbox/2.0.24/pdfbox-app-2.0.24.jar',
+  [constants.VENDOR_TIKA_JAR]: 'http://archive.apache.org/dist/tika/2.1.0/tika-app-2.1.0.jar'
 }
 
 const download = (filename) => {


### PR DESCRIPTION
Hello, the actual url returns a 404 error. 

I discover the new url on /dist with the files. 

Many thanks !