### PR TITLE
update VENDOR_TIKA_JAR version to 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,5 +110,5 @@ Sometimes downloading the dependencies might be too slow or unable to download i
 cd node_modules/pdf2html/vendor
 # These URLs come from https://github.com/shebinleo/pdf2html/blob/master/postinstall.js#L6-L7
 wget https://dlcdn.apache.org/pdfbox/2.0.25/pdfbox-app-2.0.25.jar
-wget https://dlcdn.apache.org/tika/2.2.1/tika-app-2.2.1.jar
+wget https://dlcdn.apache.org/tika/2.2.1/tika-app-2.3.0.jar
 ```

--- a/README.md
+++ b/README.md
@@ -110,5 +110,5 @@ Sometimes downloading the dependencies might be too slow or unable to download i
 cd node_modules/pdf2html/vendor
 # These URLs come from https://github.com/shebinleo/pdf2html/blob/master/postinstall.js#L6-L7
 wget https://dlcdn.apache.org/pdfbox/2.0.25/pdfbox-app-2.0.25.jar
-wget https://dlcdn.apache.org/tika/2.2.1/tika-app-2.3.0.jar
+wget https://dlcdn.apache.org/tika/2.3.0/tika-app-2.3.0.jar
 ```

--- a/constants.js
+++ b/constants.js
@@ -3,7 +3,7 @@ const path = require('path')
 module.exports = {
 
   VENDOR_PDF_BOX_JAR: 'pdfbox-app-2.0.25.jar',
-  VENDOR_TIKA_JAR: 'tika-app-2.2.1.jar',
+  VENDOR_TIKA_JAR: 'tika-app-2.3.0.jar',
 
   DIRECTORY: {
     PDF: path.join(__dirname, './files/pdf/'),

--- a/postinstall.js
+++ b/postinstall.js
@@ -4,7 +4,7 @@ const constants = require('./constants')
 
 const dependencies = {
   [constants.VENDOR_PDF_BOX_JAR]: 'https://dlcdn.apache.org/pdfbox/2.0.25/pdfbox-app-2.0.25.jar',
-  [constants.VENDOR_TIKA_JAR]: 'https://dlcdn.apache.org/tika/2.2.1/tika-app-2.2.1.jar'
+  [constants.VENDOR_TIKA_JAR]: 'https://dlcdn.apache.org/tika/2.3.0/tika-app-2.3.0.jar'
 }
 
 const download = (filename) => {


### PR DESCRIPTION
Fixing missing Tika 2.2.1.jar by upgrading the Tika to 2.3.0 
Resolving #25