### PR TITLE
updated to pdfbox version 2.0.26 since 2.0.25 no longer available for download

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const constants = require('./constants')
 
 const dependencies = {
-  [constants.VENDOR_PDF_BOX_JAR]: 'https://dlcdn.apache.org/pdfbox/2.0.25/pdfbox-app-2.0.25.jar',
+  [constants.VENDOR_PDF_BOX_JAR]: 'https://dlcdn.apache.org/pdfbox/2.0.26/pdfbox-app-2.0.26.jar',
   [constants.VENDOR_TIKA_JAR]: 'https://dlcdn.apache.org/tika/2.3.0/tika-app-2.3.0.jar'
 }
 


### PR DESCRIPTION
When attempting to install pdf2html the install fails because the pdfbox .jar file is no longer available for version 2.0.25, so instead should use 2.0.26.