### PR TITLE
Updating vendor download url of Tika

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -4,7 +4,7 @@ const constants = require('./constants')
 
 const dependencies = {
   [constants.VENDOR_PDF_BOX_JAR]: 'https://dlcdn.apache.org/pdfbox/2.0.26/pdfbox-app-2.0.26.jar',
-  [constants.VENDOR_TIKA_JAR]: 'https://dlcdn.apache.org/tika/2.3.0/tika-app-2.3.0.jar'
+  [constants.VENDOR_TIKA_JAR]: 'https://archive.apache.org/dist/tika/2.4.0/tika-app-2.4.0.jar'
 }
 
 const download = (filename) => {


### PR DESCRIPTION
Updating the url to the last active version and use the archive url to avoid 404 errors when a new version is released.