### PR TITLE
max buffer is customisable now #43

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,25 @@ const textPages = await pdf2html.pages('sample.pdf', options);
 console.log(textPages);
 ```
 
-#### Extra metadata
+#### Extract metadata
 
 ```javascript
 const meta = await pdf2html.meta('sample.pdf');
 console.log(meta);
+```
+
+#### Customize maximum buffer to be used
+
+The maxBuffer option specifies the largest number of bytes allowed on stdout or stderr. If this value is exceeded, then the child process is terminated.
+
+By default, the maximum buffer size is 2MB. You can customize it by passing the `maxBuffer` option.
+
+```javascript
+await pdf2html.meta('sample.pdf', { maxBuffer: 1024 * 10000 }); // set maxBuffer to 10MB
+await pdf2html.html('sample.pdf', { maxBuffer: 1024 * 10000 });
+await pdf2html.text('sample.pdf', { maxBuffer: 1024 * 10000 });
+await pdf2html.pages('sample.pdf', { maxBuffer: 1024 * 10000 });
+await pdf2html.thumbnail('sample.pdf', { maxBuffer: 1024 * 10000 });
 ```
 
 #### Generate thumbnail

--- a/index.js
+++ b/index.js
@@ -60,9 +60,10 @@ const runPDFBox = async (filepath, _options) => {
     const copyFilePath = constants.DIRECTORY.PDF + uri.filename();
     await fse.copy(filepath, copyFilePath);
 
+    const maxBuffer = options.maxBuffer || 1024 * 2000;
     const command = 'java';
     const commandArgs = ['-jar', `${constants.DIRECTORY.VENDOR + constants.VENDOR_PDF_BOX_JAR}`, 'PDFToImage', '-imageType', options.imageType, '-startPage', options.page, '-endPage', options.page, copyFilePath];
-    await executeCommand(command, commandArgs, { maxBuffer: 1024 * 2000 });
+    await executeCommand(command, commandArgs, { maxBuffer });
 
     uri.suffix(options.imageType);
 
@@ -84,23 +85,24 @@ const runPDFBox = async (filepath, _options) => {
     return imageFilePath;
 };
 
-const runTika = async (filepath, _commandOption) => {
+const runTika = async (filepath, _commandOption, options) => {
+    const maxBuffer = (options && options.maxBuffer) || 1024 * 2000;
     const commandOption = _commandOption || 'html';
     const command = 'java';
     const commandArgs = ['-jar', `${constants.DIRECTORY.VENDOR + constants.VENDOR_TIKA_JAR}`, `--${commandOption}`, filepath];
-    return executeCommand(command, commandArgs, { maxBuffer: 1024 * 2000 });
+    return executeCommand(command, commandArgs, { maxBuffer });
 };
 
-const html = async (filepath) => {
+const html = async (filepath, options) => {
     debug('Converts PDF to HTML');
-    return runTika(filepath, 'html');
+    return runTika(filepath, 'html', options);
 };
 
 const pages = async (filepath, _options) => {
     const options = defaults(_options || {}, { text: false });
 
     debug('Converts PDF to HTML pages');
-    const result = await html(filepath);
+    const result = await html(filepath, options);
     const $ = cheerio.load(result);
     const htmlPages = [];
     const $pages = $('.page');
@@ -111,14 +113,14 @@ const pages = async (filepath, _options) => {
     return htmlPages;
 };
 
-const text = async (filepath) => {
+const text = async (filepath, options) => {
     debug('Converts PDF to Text');
-    return runTika(filepath, 'text');
+    return runTika(filepath, 'text', options);
 };
 
-const meta = async (filepath) => {
+const meta = async (filepath, options) => {
     debug('Extracts meta information from PDF');
-    return JSON.parse(await runTika(filepath, 'json'));
+    return JSON.parse(await runTika(filepath, 'json', options));
 };
 
 const thumbnail = async (filepath, options) => {


### PR DESCRIPTION
This will be to handle big files like the one mentioned in #43

```javascript
await pdf2html.meta('sample.pdf', { maxBuffer: 1024 * 10000 }); // set maxBuffer to 10MB
await pdf2html.html('sample.pdf', { maxBuffer: 1024 * 10000 });
await pdf2html.text('sample.pdf', { maxBuffer: 1024 * 10000 });
await pdf2html.pages('sample.pdf', { maxBuffer: 1024 * 10000 });
await pdf2html.thumbnail('sample.pdf', { maxBuffer: 1024 * 10000 });
```